### PR TITLE
Multiple sitemaps check

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
 #Application-Tester
 
-Application for checking wether your website redirects to `www` and `https`
+Application that checks whether your website redirects to `www` and `https`
 
-Also checks the existance of **robots.txt** and **sitemap.yaml**
+Also checks for the existance of **robots.txt** and **sitemap.xml**
 
 ##Installation
 

--- a/lib/application_tester.rb
+++ b/lib/application_tester.rb
@@ -18,9 +18,9 @@ class Application_tester
   def robots_check
     website = RobotsFile.new(url)
     puts "Robots.txt exists: #{website.exists?}"
-    puts "Has a link to the Sitemap: #{website.has_sitemap_link?}"
+    puts "Number of Sitemaps: #{website.sitemaps_count}"
     if website.has_sitemap_link?
-      puts "Sitemap file is empty: #{website.sitemap_is_empty?}"
+      puts "Sitemap files are not empty: #{!website.all_sitemaps_empty?}"
     end
   end
 

--- a/lib/application_tester.rb
+++ b/lib/application_tester.rb
@@ -6,13 +6,18 @@ class Application_tester
   attr_reader :url
 
   def initialize(url)
-    @url=url
+    @url = url
+  end
+
+  def update_url (new_url)
+    initialize(new_url)
   end
 
   def redirection_check
     website = Redirection.new(url)
     puts "Redirects to www: #{website.redirects_to_www?}"
     puts "Redirects to https: #{website.redirects_to_https?}"
+    update_url(website.redirection)
   end
 
   def robots_check

--- a/lib/redirection.rb
+++ b/lib/redirection.rb
@@ -19,7 +19,7 @@ class Redirection < UrlRequest
   end
 
   def includes_https?
-    get.header['location'].include?("https")
+    get.header['Location'].include?("https")
   end
 
 end

--- a/lib/redirection.rb
+++ b/lib/redirection.rb
@@ -8,6 +8,13 @@ class Redirection < UrlRequest
     is_redirected? && includes_https?
   end
 
+  def redirection
+    if is_redirected?
+      return get.header['Location']
+    end
+    uri.to_s
+  end
+
   private
 
   def is_redirected?

--- a/lib/url_request.rb
+++ b/lib/url_request.rb
@@ -18,6 +18,10 @@ class UrlRequest
     Net::HTTP.get_response(parse(url))
   end
 
+  def request_code (url)
+    get_request(url).code
+  end
+
   private
   attr_reader :uri
 end

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe Redirection do
       end
     end
   end
+
+  describe "#redirection" do
+    subject { url_request.redirection }
+
+    context "redirects to https" do
+      it "returns a new url" do
+        expect(subject).to eq "https://www.test.com/"
+      end
+    end
+
+    context "does not redirect to https" do
+      let(:url_request) { described_class.new("http://testfail.com") }
+
+      it "returns the same url" do
+        expect(subject).to eq "http://testfail.com"
+      end
+    end
+  end
 end

--- a/spec/models/robots_file_spec.rb
+++ b/spec/models/robots_file_spec.rb
@@ -39,12 +39,30 @@ RSpec.describe RobotsFile do
     end
   end
 
-  describe "#sitemap_is_empty?" do
-    subject { url_request.sitemap_is_empty? }
+  describe "#sitemaps_count" do
+    subject { url_request.sitemaps_count }
 
-    context "sitemap file is  not empty" do
-      it "returns false" do
-        expect(subject).to eq false
+    it "returns number of sitemaps specified" do
+      expect(subject).to eq 1
+    end
+  end
+
+  describe "#all_sitemaps_empty?" do
+    subject { url_request.all_sitemaps_empty? }
+
+    context "sitemap files are not empty" do
+      context "sitemap link is redirected" do
+
+        it "returns false" do
+          expect(subject).to eq false
+        end
+      end
+
+      context "sitemap link is not redirected" do
+        let(:url_request) { described_class.new("http://www.testnoredirection.com") }
+        it "returns false" do
+          expect(subject).to eq false
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,9 +30,10 @@ RSpec.configure do |config|
     stub_request(:get, '/www.test.com/robots.txt').to_return(status: 200, body: "Disallow: /\nSitemap: http://www.test.com/sitemap.xml.gz\n")
     stub_request(:get, '/www.testfail.com/robots.txt').to_return(status: 404)
     stub_request(:get, '/www.test.com/sitemap.xml.gz').to_return(status: 301, headers: { Location:  "http://www.test.com/redirected_sitemap.xml.gz" })
-    stub_request(:get, 'http://www.test.com/redirected_sitemap.xml.gz').to_return(status: 200, :headers => { 'Content-Length' => 5 })
+    stub_request(:get, '/www.test.com/redirected_sitemap.xml.gz').to_return(status: 200, :headers => { 'Content-Length' => 5 })
     stub_request(:get, '/www.testfailmap.com/robots.txt').to_return(status: 200, body: "Disallow: /\nSitemap: http://www.testfail.com/sitemap.xml.gz\n")
     stub_request(:get, '/www.testfail.com/sitemap.xml.gz').to_return(status: 404)
+    stub_request(:get, '/www.testnoredirection.com/robots.txt').to_return(status: 200, body: "Disallow: /\nSitemap: http://www.test.com/redirected_sitemap.xml.gz\n")
   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Add methods that check all sitemap files, in case there is more than one listed in robots.txt

If at least one sitemap file is empty or does not exists the user gets notified, without specifying the particular one
